### PR TITLE
fix: display from audit form container changed from grid to flex

### DIFF
--- a/src/components/AuditForm.vue
+++ b/src/components/AuditForm.vue
@@ -88,9 +88,9 @@ export default {
 
 <style scoped>
 .form-container {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: var(--spacing);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   background: var(--color-surface);
   padding: var(--spacing);
   border-radius: var(--radius);


### PR DESCRIPTION
Corrected the view of the container, there was a misalignment between the field and field label, there were side to side. Now the form was changed to a flex format, in which the label stays over the field.